### PR TITLE
Fix link to MetaCPAN

### DIFF
--- a/_includes/documentation.html
+++ b/_includes/documentation.html
@@ -11,7 +11,7 @@
                 <div class="col-lg-4 col-lg-offset-2">
                     <h3>Official Doc's</h3>
                     <ul>
-                        <li>FormFu on <a href="https://metacpan.org/pod/HTML-FormFu">MetaCPAN</a></li>
+                        <li>FormFu on <a href="https://metacpan.org/pod/HTML::FormFu">MetaCPAN</a></li>
                         <li>Working with <a href="https://metacpan.org/pod/HTML::FormFu::Manual::Unicode">Unicode</a></li>
                         <li>Using FormFu with <a href="https://metacpan.org/pod/HTML::FormFu::Model::DBIC">DBIx::Class</a></li>
                         <li><a href="https://metacpan.org/pod/HTML::FormFu::Imager">Imager helpers</a> for FormFu</li>


### PR DESCRIPTION
In the /pod/ links, the package name must be used.